### PR TITLE
Make module.json compatible with Foundry V10

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,15 +1,22 @@
 {
+    "id": "one-page-parser",
     "name": "one-page-parser",
     "title": "One Page Parser",
     "description": "Import instant scenes from One Page Dungeon",
     "author": "Tarkan Al-Kazily",
+    "authors": [ { "name": "Tarkan Al-Kazily"} ],
     "version": "0.5.1",
     "minimumCoreVersion": "0.8.6",
-    "compatibleCoreVersion" : "0.8.8",
+    "compatibleCoreVersion" : "10",
     "esmodules": [
         "scripts/one_page_parser.js",
         "scripts/hello.js"
     ],
+    "compatibility": {
+        "minimum": "0.8.6",
+        "verified": "10",
+        "maximum": "10"
+    },
     "url": "https://github.com/TarkanAl-Kazily/one-page-parser",
     "manifest": "https://github.com/TarkanAl-Kazily/one-page-parser/releases/latest/download/module.json",
     "download": "https://github.com/TarkanAl-Kazily/one-page-parser/archive/main.zip"

--- a/module.json
+++ b/module.json
@@ -14,8 +14,7 @@
     ],
     "compatibility": {
         "minimum": "0.8.6",
-        "verified": "10",
-        "maximum": "10"
+        "verified": "10"
     },
     "url": "https://github.com/TarkanAl-Kazily/one-page-parser",
     "manifest": "https://github.com/TarkanAl-Kazily/one-page-parser/releases/latest/download/module.json",


### PR DESCRIPTION
A quick test shows that the module still works in Foundry V10, but it is reporting compatibility warnings.
The changed module.json contains the new syntax required by Foundry V10 to not show these warnings.